### PR TITLE
Added locale parameter to get_document methods

### DIFF
--- a/src/strapi_client/strapi_client.py
+++ b/src/strapi_client/strapi_client.py
@@ -65,9 +65,10 @@ class StrapiClient(StrapiClientBase):
             document_id: str,
             populate: list[str] | dict[str, Any] | str | None = None,
             fields: list[str] | None = None,
+            locale: str | None = None
     ) -> DocumentResponse:
         """Get document by document id."""
-        params = ApiParameters(populate=populate, fields=fields)
+        params = ApiParameters(populate=populate, fields=fields, locale=locale)
         res = self.send_get_request(
             f"{plural_api_id}/{document_id}",
             params=params.stringify()

--- a/src/strapi_client/strapi_client_async.py
+++ b/src/strapi_client/strapi_client_async.py
@@ -65,9 +65,10 @@ class StrapiClientAsync(StrapiClientBase):
             document_id: str,
             populate: list[str] | dict[str, Any] | str | None = None,
             fields: list[str] | None = None,
+            locale: str | None = None
     ) -> DocumentResponse:
         """Get document by document id."""
-        params = ApiParameters(populate=populate, fields=fields)
+        params = ApiParameters(populate=populate, fields=fields, locale=locale)
         res = await self.send_get_request(
             f"{plural_api_id}/{document_id}",
             params=params.stringify()


### PR DESCRIPTION
Given that different locales for the same document share the same document_id, a way to retrieve specific locales with the sdk was needed.

I added it (library was already capable of it but it lacked the necessary kwarg)